### PR TITLE
fix: 🐛 allow files in registry to be access on edge

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  outputFileTracingIncludes: {
+    registry: ["./registry/**/*"],
+  },
   /* config options here */
 };
 


### PR DESCRIPTION
## Goals/Scope

There is an issue with the ./app/registry/[name]/route.ts` function where it works locally, but not in production.  On the local deployment you get the JSON response with the files and content, but deployed in Vercel I get back as a response:
```json
{
"error": "Something went wrong"
}
```
And in the vercel logs its reads:
```bash
Error processing component request: Error: ENOENT: no such file or directory, open '/var/task/registry/button.stories.tsx'
    at async (.next/server/app/registry/[name]/route.js:1:62728)
    at async tx (.next/server/app/registry/[name]/route.js:1:62649) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/var/task/registry/button.stories.tsx'
}
```
Brought this up initially in https://github.com/shadcn-ui/ui/pull/6380#issuecomment-2611063803 but in the process of looking for a reference ended up finding the solution.

## Description

The solution for this comes from a guide on Node File tracing on Vercel ([here](https://vercel.com/guides/how-can-i-use-files-in-serverless-functions)) where it is outlined that its needed to use the `outputFileTracingIncludes` config in the `next.config.ts` in order to expose the registry files so the `route.ts` function can access the file system.

Adding this blob to the whole registry directory fixes the issue 👍 

### How to Test

1. Open the project locally
2. Route to http://localhost:3000/registry/hello-world
3. See valid JSON response ✅ 
4. Deploy the project to vercel
5. Route to https://<Vercel deployment>/registry/hello-world
3. See valid JSON response ✅ 

## Comments
<!--- Add any additional comments -->

---
- [x] cc: @shadcn 