### PR TITLE
perf: ⚡ generate static params from registry.json

### DIFF
--- a/app/registry/[name]/route.ts
+++ b/app/registry/[name]/route.ts
@@ -3,6 +3,16 @@ import path from "path"
 import { promises as fs } from "fs"
 import { registryItemSchema } from "shadcn/registry"
 
+// Use the registry.json file to generate static paths.
+export const generateStaticParams = async () => {
+  const registryData = await import("@/registry.json");
+  const registry = registryData.default;
+
+  return registry.items.map((item) => ({
+    name: item.name,
+  }));
+};
+
 // This route shows an example for serving a component using a route handler.
 export async function GET(
   request: Request,


### PR DESCRIPTION
## Goals/Scope

After getting the routing working and taking a look at the build I realised there are some optimisations that could be done with generating the params using the `registry.json`. This should turn the routes into SSG instead of Dynamic which will save some CPU time on edge functions and reduce potential costs.

## Description

Just added the `generateStaticParams` to fetch the `registry.json` and map out all the item names.  The result:

```bash
Route (app)                              Size     First Load JS
┌ ○ /                                    9.28 kB         114 kB
├ ○ /_not-found                          982 B           106 kB
└ ● /registry/[name]                     135 B           105 kB
    ├ /registry/complex-component
    ├ /registry/example-form
    └ /registry/hello-world
+ First Load JS shared by all            105 kB
  ├ chunks/4bd1b696-1e3aa08efae9c30b.js  53 kB
  ├ chunks/517-44104b656c9b8dc3.js       50.3 kB
  └ other shared chunks (total)          1.84 kB


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

---

- [x] cc: @shadcn 
